### PR TITLE
Changed install instructions to use editable mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ git clone https://github.com/brianzi/quantumsim
 git clone https://github.com/obriente/qsoverlay
 cd quantumsim
 git checkout Noisy_twoqubit
-pip install .
+pip install -e .
 cd ../qsoverlay
-pip install .
+pip install -e .
 ```
 
 


### PR DESCRIPTION
Changed pip install to use editable mode. This ensures that installation creates a symlink to your git repository instead of a copy of the current state. This is important when using a git based installation as otherwise it can be tricky to update. 