### PR TITLE
Fixing time parameter support for some gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+NOTE: 
+Always specify gate time, ex `b.gate('X', ['1'], time = 10)`, where the `b` is a builder instance, and the time is the middle temporal of the gate's execution.
+Plus, always correct the builder class timing at the end:
+```
+b.times = {'1': 20}
+```
+
 Installation
 ------------
 

--- a/qsoverlay/circuit_builder.py
+++ b/qsoverlay/circuit_builder.py
@@ -228,9 +228,19 @@ class Builder:
 
         num_qubits = self.gate_dic[gate_name]['num_qubits']
         user_kws = self.gate_dic[gate_name]['user_kws']
+        time = None
 
         if len(gate_desc) == len(user_kws) + num_qubits + 2:
+            if type(gate_desc[-1]) is bool:
+                return_flag = gate_desc[-1]
+            else:
+                return_flag = False
+                time = gate_desc[-1]
+        elif len(gate_desc) == len(user_kws) + num_qubits + 3:
+            assert gate_desc[-1] == bool
+            assert gate_desc[-2] == float or gate_desc[-2] == int
             return_flag = gate_desc[-1]
+            time = gate_desc[-2]
         else:
             assert len(gate_desc) == len(user_kws) + num_qubits + 1
             return_flag = False
@@ -239,6 +249,8 @@ class Builder:
 
         kwargs = {kw: arg for kw, arg in
                   zip(user_kws, gate_desc[num_qubits+1:])}
+        if time:
+            kwargs['time'] = time
 
         return self.add_gate(gate_name, qubit_list,
                              return_flag=return_flag, **kwargs)

--- a/qsoverlay/gate_functions.py
+++ b/qsoverlay/gate_functions.py
@@ -8,36 +8,36 @@ from numpy import pi
 
 
 def X_gate(builder, bit, time):
-    builder < ('RX', bit, -pi)
+    builder < ('RX', bit, -pi, time)
 
 
 def Y_gate(builder, bit, time):
-    builder < ('RY', bit, -pi)
+    builder < ('RY', bit, -pi, time)
 
 
 def Z_gate(builder, bit, time):
-    builder < ('RZ', bit, -pi)
+    builder < ('RZ', bit, -pi, time)
 
 
 def had_from_rot(builder, bit, time):
     """Creates a Hadamard gate from two rotations."""
-    builder < ('RX', bit, -pi)
-    builder < ('RY', bit, -pi / 2)
+    builder < ('RX', bit, -pi, time)
+    builder < ('RY', bit, -pi / 2, time)
 
 
 def CNOT_from_CZ(builder, bit0, bit1, time):
     """Creates a CNOT gate from a CZ gate"""
-    builder < ('RY', bit1, -pi / 2)
-    builder < ('CZ', bit0, bit1)
-    builder < ('RY', bit1, pi / 2)
+    builder < ('RY', bit1, -pi / 2, time)
+    builder < ('CZ', bit0, bit1, time)
+    builder < ('RY', bit1, pi / 2, time)
 
 
 def CRX_from_CZ(builder, bit0, bit1, angle, time):
     """Creates a CNOT gate from a CZ gate"""
-    builder < ('RY', bit1, -pi / 2)
-    builder < ('RZ', bit0, -angle / 2)
-    builder < ('CPhase', bit0, bit1, angle)
-    builder < ('RY', bit1, pi / 2)
+    builder < ('RY', bit1, -pi / 2, time)
+    builder < ('RZ', bit0, -angle / 2, time)
+    builder < ('CPhase', bit0, bit1, angle, time)
+    builder < ('RY', bit1, pi / 2, time)
 
 
 def insert_CZ(builder,


### PR DESCRIPTION
As a result of finding a bug in #19 where some gates would disregard the `time` argument during the `b.add_gate`, I made some changes to the code:

In `qsoverlay/gate_functions.py`, the functions `X_gate`, `Y_gate`, `Z_gate`, `had_from_rot`, `CNOT_from_CZ`, `CRX_from_CZ` failed to use the time parameter in a meaningful manner. I added the parameter to the tuple passed to `circuit_builder.__lt__`.

In `qsoverlay/circuit_builder.py `, in ` Builder.__lt__`, I modified the conditions which verified the  `len(gate_desc)`, in order to make them support the usage of the `time` AND/OR `return_flag`. It however assumes that, if both flags are used, `time` should precede `return_flags`.

These changes should fix the bugs during the construction of `circuit_builder` circuits via the `add_gate` method. It is still necessary to add time support to other places where `Builder.__lt__` is called. In the meantime, the changes I made shouldn't cause any conflict with those, however.

Regards,
Diogo Valada